### PR TITLE
update the used api to include v1/

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_API=https://montessori-ressources-api.herokuapp.com
+REACT_APP_API=https://montessori-ressources-api.herokuapp.com/v1


### PR DESCRIPTION
Because maybe one day we will have a `v2`

Will fix montessori-ressources/api#2