### PR TITLE
add crop marks on the pdf for both image and label

### DIFF
--- a/src/components/pdf/nomenclature.js
+++ b/src/components/pdf/nomenclature.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Document, Page, Text, View, Image, StyleSheet } from '@react-pdf/renderer'
+import { Document, Page, Text, View, Image, StyleSheet, Canvas } from '@react-pdf/renderer'
 import { useParams } from 'react-router-dom'
 import { PDFViewer } from '@react-pdf/renderer'
 import client from '../../tools/client'
@@ -37,6 +37,13 @@ const styles = StyleSheet.create({
   viewer: {
     height: "600px",
     width: "100%",
+  },
+  canvas: {
+    height: "10px",
+    width: "13.5cm"
+  },
+  text: {
+    marginTop: "10px",
   }
 });
 
@@ -87,6 +94,13 @@ const NomenclaturePage = (props) => {
     <Page wrap={false} key={props.pageId} size="A4" orientation="landscape" style={styles.page}>
       {props.cards.map((card) => (
         <View key={card.id} style={styles.section}>
+          <Canvas style={styles.canvas}
+              paint={painter =>
+              painter
+                .moveTo(10, 0).lineTo(10, 10).lineTo(0, 10).stroke()
+                .moveTo(372, 0).lineTo(372, 10).lineTo(382, 10).stroke()
+                }
+          />
           <Image 
             style={styles.image} 
             source={{
@@ -94,7 +108,31 @@ const NomenclaturePage = (props) => {
               headers: { Pragma: 'no-cache', 'Cache-Control': 'no-cache' },
             }}
           />
-          <Text style={styles.label}>{card.originalname}</Text>
+          <Canvas style={styles.canvas}
+              paint={painter =>
+              painter
+                .moveTo(0, 0).lineTo(10, 0).lineTo(10, 10).stroke()
+                .moveTo(372, 10).lineTo(372, 0).lineTo(382, 0).stroke()
+                }
+          />
+          <View style={styles.text}>
+            <Canvas style={styles.canvas}
+                paint={painter =>
+                painter
+                  .moveTo(10, 0).lineTo(10, 10).lineTo(0, 10).stroke()
+                  .moveTo(372, 0).lineTo(372, 10).lineTo(382, 10).stroke()
+                  }
+            />
+            <Text style={styles.label}>{card.originalname}</Text>
+            <Canvas style={styles.canvas}
+                paint={painter =>
+                painter
+                  .moveTo(0, 0).lineTo(10, 0).lineTo(10, 10).stroke()
+                  .moveTo(372, 10).lineTo(372, 0).lineTo(382, 0).stroke()
+                  }
+            />
+          </View>
+          
         </View>
       ))}
       <Text style={styles.footer} fixed>


### PR DESCRIPTION
To fix #43 

I have used the `<Canvas>` element of [react-pdf](https://react-pdf.org/components#canvas). We just need to implement the `painter` prop with a [pdfkit](http://pdfkit.org/docs/vector.html) specification.

![image](https://user-images.githubusercontent.com/4988590/97768528-02706a80-1afa-11eb-9eaa-f09d5ebbc2a4.png)

We can adjust the length of the crop marks (10px for now)